### PR TITLE
feat: use request IRI as parser baseIRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The factory accepts the following options:
 - `factory`: The factory used to create Dataset instances. Default: `require('rdf-ext')`
 - `formats`: An object with `parsers` and `serializers`, each given as `@rdfjs/sink-map`. Default: `require('@rdfjs/formats-common')`
 - `defaultMediaType`: If an unknown Content-Type is given, this media type will be used. Default: `undefined`
+- `baseIRI`: If `true`, will call [absolute-url](https://npm.im/absolute-url) to get the requested IRI and pass as base IRI to the parser. It can also be a function `async (req) => string` which can be used to compute the base IRI for the parser.
 
 ### Request
 

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const rdf = require('@rdfjs/dataset')
 const { fromStream, toStream } = require('rdf-dataset-ext')
 const { promisify } = require('util')
 const { PassThrough } = require('readable-stream')
+const absoluteUrl = require('absolute-url')
 
 async function readDataset ({ factory, options, req }) {
   return fromStream(factory.dataset(), req.quadStream(options))
@@ -50,7 +51,11 @@ async function sendQuadStream ({ defaultMediaType, formats, options, quadStream,
 function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, baseIriFromRequest } = {}) {
   let getBaseIri
   if (baseIriFromRequest === true) {
-    getBaseIri = (req) => req.absoluteUrl()
+    getBaseIri = (req) => {
+      absoluteUrl.attach(req)
+
+      return req.absoluteUrl()
+    }
   } else if (typeof baseIriFromRequest === 'function') {
     getBaseIri = baseIriFromRequest
   }

--- a/index.js
+++ b/index.js
@@ -47,12 +47,12 @@ async function sendQuadStream ({ defaultMediaType, formats, options, quadStream,
   })
 }
 
-function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, baseIRI } = {}) {
+function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, baseIriFromRequest } = {}) {
   let getBaseIri
-  if (baseIRI === true) {
+  if (baseIriFromRequest === true) {
     getBaseIri = (req) => req.absoluteUrl()
-  } else if (typeof baseIRI === 'function') {
-    getBaseIri = baseIRI
+  } else if (typeof baseIriFromRequest === 'function') {
+    getBaseIri = baseIriFromRequest
   }
 
   // middleware

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   "dependencies": {
     "@rdfjs/dataset": "^1.0.1",
     "@rdfjs/formats-common": "^2.0.0",
+    "absolute-url": "^1.2.2",
     "http-errors": "^1.7.2",
     "isstream": "^0.1.2",
-    "rdf-dataset-ext": "^1.0.0"
+    "rdf-dataset-ext": "^1.0.0",
+    "readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "@rdfjs/sink-map": "^1.0.0",

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -149,7 +149,7 @@ describe('request', () => {
       })
 
       app.use(absoluteUrl())
-      app.use(rdfHandler({ formats, baseIRI: true }))
+      app.use(rdfHandler({ formats, baseIriFromRequest: true }))
       app.use(async (req, res, next) => {
         await req.dataset()
 
@@ -177,7 +177,7 @@ describe('request', () => {
         }
       })
 
-      app.use(rdfHandler({ formats, baseIRI: () => 'http://example.com/resource-base/' }))
+      app.use(rdfHandler({ formats, baseIriFromRequest: () => 'http://example.com/resource-base/' }))
       app.use(async (req, res, next) => {
         await req.dataset()
 
@@ -306,7 +306,7 @@ describe('request', () => {
       })
 
       app.use(absoluteUrl())
-      app.use(rdfHandler({ formats, baseIRI: true }))
+      app.use(rdfHandler({ formats, baseIriFromRequest: true }))
       app.use(async (req, res, next) => {
         await req.quadStream()
 
@@ -334,7 +334,7 @@ describe('request', () => {
         }
       })
 
-      app.use(rdfHandler({ formats, baseIRI: () => 'http://example.com/resource-base/' }))
+      app.use(rdfHandler({ formats, baseIriFromRequest: () => 'http://example.com/resource-base/' }))
       app.use(async (req, res, next) => {
         await req.quadStream()
 

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -6,7 +6,6 @@ const express = require('express')
 const formatsMock = require('./support/formatsMock')
 const isStream = require('isstream')
 const rdf = require('@rdfjs/dataset')
-const absoluteUrl = require('absolute-url')
 const { fromStream, toCanonical } = require('rdf-dataset-ext')
 const rdfHandler = require('../')
 const request = require('supertest')
@@ -148,7 +147,6 @@ describe('request', () => {
         }
       })
 
-      app.use(absoluteUrl())
       app.use(rdfHandler({ formats, baseIriFromRequest: true }))
       app.use(async (req, res, next) => {
         await req.dataset()
@@ -305,7 +303,6 @@ describe('request', () => {
         }
       })
 
-      app.use(absoluteUrl())
       app.use(rdfHandler({ formats, baseIriFromRequest: true }))
       app.use(async (req, res, next) => {
         await req.quadStream()

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -6,6 +6,7 @@ const express = require('express')
 const formatsMock = require('./support/formatsMock')
 const isStream = require('isstream')
 const rdf = require('@rdfjs/dataset')
+const absoluteUrl = require('absolute-url')
 const { fromStream, toCanonical } = require('rdf-dataset-ext')
 const rdfHandler = require('../')
 const request = require('supertest')
@@ -131,7 +132,63 @@ describe('request', () => {
         .set('content-type', 'text/plain')
         .send('')
 
-      assert.strictEqual(givenOptions, options)
+      assert.deepStrictEqual(givenOptions, options)
+    })
+
+    it('should pass base IRI to parser when set on handler', async () => {
+      let givenOptions = null
+      const options = {
+        baseIRI: 'http://example.com/resource/name'
+      }
+      const app = express()
+
+      const formats = formatsMock({
+        parse: (stream, options) => {
+          givenOptions = options
+        }
+      })
+
+      app.use(absoluteUrl())
+      app.use(rdfHandler({ formats, baseIRI: true }))
+      app.use(async (req, res, next) => {
+        await req.dataset()
+
+        next()
+      })
+
+      await request(app).post('/resource/name')
+        .set('content-type', 'text/plain')
+        .set('host', 'example.com')
+        .send('')
+
+      assert.deepStrictEqual(givenOptions, options)
+    })
+
+    it('should pass computed base IRI to parser when set on handler', async () => {
+      let givenOptions = null
+      const options = {
+        baseIRI: 'http://example.com/resource-base/'
+      }
+      const app = express()
+
+      const formats = formatsMock({
+        parse: (stream, options) => {
+          givenOptions = options
+        }
+      })
+
+      app.use(rdfHandler({ formats, baseIRI: () => 'http://example.com/resource-base/' }))
+      app.use(async (req, res, next) => {
+        await req.dataset()
+
+        next()
+      })
+
+      await request(app).post('/resource/name')
+        .set('content-type', 'text/plain')
+        .send('')
+
+      assert.deepStrictEqual(givenOptions, options)
     })
   })
 
@@ -232,7 +289,63 @@ describe('request', () => {
         .set('content-type', 'text/plain')
         .send('')
 
-      assert.strictEqual(givenOptions, options)
+      assert.deepStrictEqual(givenOptions, options)
+    })
+
+    it('should pass base IRI to parser when set on handler', async () => {
+      let givenOptions = null
+      const options = {
+        baseIRI: 'http://example.com/resource/name'
+      }
+      const app = express()
+
+      const formats = formatsMock({
+        parse: (stream, options) => {
+          givenOptions = options
+        }
+      })
+
+      app.use(absoluteUrl())
+      app.use(rdfHandler({ formats, baseIRI: true }))
+      app.use(async (req, res, next) => {
+        await req.quadStream()
+
+        next()
+      })
+
+      await request(app).post('/resource/name')
+        .set('content-type', 'text/plain')
+        .set('host', 'example.com')
+        .send('')
+
+      assert.deepStrictEqual(givenOptions, options)
+    })
+
+    it('should pass computed base IRI to parser when set on handler', async () => {
+      let givenOptions = null
+      const options = {
+        baseIRI: 'http://example.com/resource-base/'
+      }
+      const app = express()
+
+      const formats = formatsMock({
+        parse: (stream, options) => {
+          givenOptions = options
+        }
+      })
+
+      app.use(rdfHandler({ formats, baseIRI: () => 'http://example.com/resource-base/' }))
+      app.use(async (req, res, next) => {
+        await req.quadStream()
+
+        next()
+      })
+
+      await request(app).post('/resource/name')
+        .set('content-type', 'text/plain')
+        .send('')
+
+      assert.deepStrictEqual(givenOptions, options)
     })
   })
 })


### PR DESCRIPTION
As discussed, this adds the `baseIRI` parameter to the handler

```js
app.use(rdfHandler({
  baseIRI: true
}))

app.use(rdfHandler({
  baseIRI: req => {
    return req.method === 'POST' ? '' : req.absoluteUrl()
  }
}))
```

I added `absolute-url` as a dependency but maybe it should be a peer dependency added by the user? `hydra-box` adds it anyway for example