### PR TITLE
added toTriple option to force sending triples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ The factory accepts the following options:
 - `factory`: The factory used to create Dataset instances. Default: `require('rdf-ext')`
 - `formats`: An object with `parsers` and `serializers`, each given as `@rdfjs/sink-map`. Default: `require('@rdfjs/formats-common')`
 - `defaultMediaType`: If an unknown Content-Type is given, this media type will be used. Default: `undefined`
-- `baseIRI`: If `true`, will call [absolute-url](https://npm.im/absolute-url) to get the requested IRI and pass as base IRI to the parser. It can also be a function `async (req) => string` which can be used to compute the base IRI for the parser.
+- `baseIriFromRequest`: If `true`, will call [absolute-url](https://npm.im/absolute-url) to get the requested IRI and pass as base IRI to the parser.
+  It can also be a function `async (req) => string` which can be used to compute the base IRI for the parser.
+- `toTriple`: If `true`, the RDF/JS Quads sent using `res.dataset()` or `res.quadStream()` are converted to triples. Default `undefined`.
 
 ### Request
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The factory accepts the following options:
 - `defaultMediaType`: If an unknown Content-Type is given, this media type will be used. Default: `undefined`
 - `baseIriFromRequest`: If `true`, will call [absolute-url](https://npm.im/absolute-url) to get the requested IRI and pass as base IRI to the parser.
   It can also be a function `async (req) => string` which can be used to compute the base IRI for the parser.
-- `toTriple`: If `true`, the RDF/JS Quads sent using `res.dataset()` or `res.quadStream()` are converted to triples. Default `undefined`.
+- `sendTriples`: If `true`, the RDF/JS Quads sent using `res.dataset()` or `res.quadStream()` are converted to triples (default graph). Default `undefined`.
 
 ### Request
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ async function sendDataset ({ dataset, options, res }) {
   await res.quadStream(toStream(dataset), options)
 }
 
-async function sendQuadStream ({ defaultMediaType, formats, options, quadStream, req, res, toTriple }) {
+async function sendQuadStream ({ defaultMediaType, formats, options, quadStream, req, res, sendTriples }) {
   // check accept header against list of serializers
   const accepts = req.accepts([...formats.serializers.keys()])
 
@@ -38,7 +38,7 @@ async function sendQuadStream ({ defaultMediaType, formats, options, quadStream,
 
   res.set('content-type', mediaType + '; charset=utf-8')
 
-  if (toTriple) {
+  if (sendTriples) {
     quadStream = quadStream.pipe(new TripleToQuad())
   }
 
@@ -53,7 +53,7 @@ async function sendQuadStream ({ defaultMediaType, formats, options, quadStream,
   })
 }
 
-function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, baseIriFromRequest, toTriple } = {}) {
+function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, baseIriFromRequest, sendTriples } = {}) {
   let getBaseIri
 
   if (baseIriFromRequest === true) {
@@ -79,7 +79,7 @@ function init ({ factory = rdf, formats = defaultFormats, defaultMediaType, base
         quadStream,
         req,
         res,
-        toTriple
+        sendTriples
       })
     }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "http-errors": "^1.7.2",
     "isstream": "^0.1.2",
     "rdf-dataset-ext": "^1.0.0",
+    "rdf-transform-triple-to-quad": "^1.0.2",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -278,10 +278,10 @@ describe('response', () => {
       assert.strictEqual(res.text, exampleQuad.nq)
     })
 
-    it('should send serialized triple content if quads are given and toTriple is true', async () => {
+    it('should send serialized triple content if quads are given and sendTriples is true', async () => {
       const app = express()
 
-      app.use(rdfHandler({ toTriple: true }))
+      app.use(rdfHandler({ sendTriples: true }))
       app.use(async (req, res) => {
         await res.quadStream(toStream(exampleQuad.dataset))
       })

--- a/test/response.test.js
+++ b/test/response.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert')
 const example = require('./support/example')
+const exampleQuad = require('./support/exampleQuad')
 const express = require('express')
 const formatsMock = require('./support/formatsMock')
 const rdf = require('@rdfjs/dataset')
@@ -249,7 +250,7 @@ describe('response', () => {
       assert.strictEqual(res.headers['content-type'], 'application/n-triples; charset=utf-8')
     })
 
-    it('should send serialized content', async () => {
+    it('should send serialized triple content', async () => {
       const app = express()
 
       app.use(rdfHandler())
@@ -259,6 +260,34 @@ describe('response', () => {
 
       const res = await request(app).get('/')
         .set('accept', 'application/n-triples')
+
+      assert.strictEqual(res.text, example.nt)
+    })
+
+    it('should send serialized quad content', async () => {
+      const app = express()
+
+      app.use(rdfHandler())
+      app.use(async (req, res) => {
+        await res.quadStream(toStream(exampleQuad.dataset))
+      })
+
+      const res = await request(app).get('/')
+        .set('accept', 'application/n-quads')
+
+      assert.strictEqual(res.text, exampleQuad.nq)
+    })
+
+    it('should send serialized triple content if quads are given and toTriple is true', async () => {
+      const app = express()
+
+      app.use(rdfHandler({ toTriple: true }))
+      app.use(async (req, res) => {
+        await res.quadStream(toStream(exampleQuad.dataset))
+      })
+
+      const res = await request(app).get('/')
+        .set('accept', 'application/n-quads, application/n-triples')
 
       assert.strictEqual(res.text, example.nt)
     })

--- a/test/support/exampleQuad.js
+++ b/test/support/exampleQuad.js
@@ -1,0 +1,17 @@
+const rdf = require('@rdfjs/dataset')
+const { toCanonical } = require('rdf-dataset-ext')
+
+const dataset = rdf.dataset([
+  rdf.quad(
+    rdf.namedNode('http://example.org/subject'),
+    rdf.namedNode('http://example.org/predicate'),
+    rdf.literal('object'),
+    rdf.namedNode('http://example.org/graph'))
+])
+
+const nq = toCanonical(dataset)
+
+module.exports = {
+  dataset,
+  nq
+}


### PR DESCRIPTION
For use cases where internal code works with quads, but the interfaces should only show triples, the option `toTriple` takes care that the serializer is feed with RDF/JS Quad objects with the `graph` property set to `DefaultGraph`.